### PR TITLE
add support for TERMs starting with "screen"; "-p" adds prefix to win…

### DIFF
--- a/psh
+++ b/psh
@@ -67,8 +67,12 @@ psh () {
             else
                 tmux new-window -c $HOME -d -n "$title" ssh -t $machine "$command"
             fi
-        elif [ "$TERM" == "screen" ] ; then
-            screen -t "$title" ssh -t $machine "$command"
+        elif [[ ${TERM} =~ screen.* ]]; then
+            if [ -n "$pane" ] ; then
+                screen -t "${pane}${title}" ssh -t $machine "$command"
+            else
+                screen -t "$title" ssh -t $machine "$command"
+            fi
         elif [ "$TERM_PROGRAM" == "Apple_Terminal" ] ; then
             osascript \
                 -e "tell application \"Terminal\"" \


### PR DESCRIPTION
Hi Karrick,

This PR adds support for termcaps starting with "screen", like "screen.xterm-256color" which is what screen uses on my Mac.  It also uses the '-p' flag to prefix the window name for screen sessions.  Thank you for your consideration!